### PR TITLE
Fix source: not found

### DIFF
--- a/app/api/Makefile
+++ b/app/api/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default banner install install-seed seed run stop db-purge api-install env-create env db db-stop api api-stop
-
+SHELL := /bin/bash 
 default: help
 
 help:


### PR DESCRIPTION
```
make[2]: 进入目录“/home/yons/RasaGPT/app/api”
Creating virtual environment ..
Environment and dependecies created already, loading ..
/bin/sh: 3: source: not found
make[2]: *** [Makefile:108：env-create] 错误 127
make[2]: 离开目录“/home/yons/RasaGPT/app/api”
make[1]: *** [Makefile:98：api-install] 错误 2
make[1]: 离开目录“/home/yons/RasaGPT/app/api”
make: *** [Makefile:35：install] 错误 2
```